### PR TITLE
Upgrade Maps SDK & MapboxDirections.swift versions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,6 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'mapbox-store-locator' do
-  pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec'
+  pod 'Mapbox-iOS-SDK', '~> 4.0'
   pod 'MapboxDirections.swift', '0.20.0'
 end

--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,6 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'mapbox-store-locator' do
-  pod 'Mapbox-iOS-SDK', '~>3.7'
-  pod 'MapboxDirections.swift', '~> 0.10'
+  pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec'
+  pod 'MapboxDirections.swift', '0.20.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,18 @@
 PODS:
-  - Mapbox-iOS-SDK (4.0.0-beta.3)
+  - Mapbox-iOS-SDK (4.0.0)
   - MapboxDirections.swift (0.20.0):
     - Polyline (~> 4.2)
   - Polyline (4.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec`)
+  - Mapbox-iOS-SDK (~> 4.0)
   - MapboxDirections.swift (= 0.20.0)
 
-EXTERNAL SOURCES:
-  Mapbox-iOS-SDK:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec
-
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 75050a566005896c9aaa5ee71c39d4186017000f
+  Mapbox-iOS-SDK: 271754e96eb4434ba1b0a8c68432e1ea26fe9841
   MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
 
-PODFILE CHECKSUM: a1c4d3ba1afedf846bcbe7ea2069726c4d26c3a2
+PODFILE CHECKSUM: 504861c6020a27c063224f534daba791dab43ae9
 
 COCOAPODS: 1.4.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,22 @@
 PODS:
-  - Mapbox-iOS-SDK (3.7.3)
-  - MapboxDirections.swift (0.15.1):
+  - Mapbox-iOS-SDK (4.0.0-beta.3)
+  - MapboxDirections.swift (0.20.0):
     - Polyline (~> 4.2)
   - Polyline (4.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (~> 3.7)
-  - MapboxDirections.swift (~> 0.10)
+  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec`)
+  - MapboxDirections.swift (= 0.20.0)
+
+EXTERNAL SOURCES:
+  Mapbox-iOS-SDK:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 5304bd9605babe6da9050ea4cb23c1671420b737
-  MapboxDirections.swift: 2ed0a698a7721b5373362b74579c7194cda12528
+  Mapbox-iOS-SDK: 75050a566005896c9aaa5ee71c39d4186017000f
+  MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
 
-PODFILE CHECKSUM: 9169d8ead9d104593d598657e583b6b63073417f
+PODFILE CHECKSUM: a1c4d3ba1afedf846bcbe7ea2069726c4d26c3a2
 
-COCOAPODS: 1.2.1
+COCOAPODS: 1.4.0

--- a/mapbox-store-locator/ThemeViewController.swift
+++ b/mapbox-store-locator/ThemeViewController.swift
@@ -182,7 +182,7 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
         if let name = feature.attribute(forKey: "name") as? String {
             
             // Change the icon to the selected icon based on the feature name. If multiple items have the same name, choose an attribute that is unique.
-            layer.iconImageName = NSExpression(format: "MGL_MATCH(name, %@, 'selected_marker', 'unselected_marker')", name)
+            layer.iconImageName = NSExpression(format: "TERNARY(name = %@, 'selected_marker', 'unselected_marker')", name)
             
         } else {
             // Deselect all items if no feature was selected.
@@ -244,7 +244,7 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
                 
                 // Set the line color to the theme's color.
                 lineStyle.lineColor = NSExpression(forConstantValue: self.viewControllerTheme?.themeColor.navigationLineColor)
-                lineStyle.lineJoin = NSExpression(forConstantValue: NSValue(mglLineCap: .round))
+                lineStyle.lineJoin = NSExpression(forConstantValue: "round")
                 lineStyle.lineWidth = NSExpression(forConstantValue: 3)
                 
                 if let userDot = mapView.style?.layer(withIdentifier: "user-location-style") {

--- a/mapbox-store-locator/ThemeViewController.swift
+++ b/mapbox-store-locator/ThemeViewController.swift
@@ -86,13 +86,15 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
         let source = MGLShapeSource(identifier: "store-locations", shape: feature, options: nil)
         style.addSource(source)
         
-        style.setImage((viewControllerTheme?.defaultMarker)!, forName: "purple_unselected_burger") // Set the default item image.
-        style.setImage((viewControllerTheme?.selectedMarker)!, forName: "purple_selected_burger") // Set the image for the selected item.
+        // Set the default item image.
+        style.setImage((viewControllerTheme?.defaultMarker)!, forName: "unselected_marker")
+        // Set the image for the selected item.
+        style.setImage((viewControllerTheme?.selectedMarker)!, forName: "selected_marker")
         
         let symbolLayer = MGLSymbolStyleLayer(identifier: "store-locations", source: source)
         
-        symbolLayer.iconImageName = MGLStyleValue(rawValue: "purple_unselected_burger")
-        symbolLayer.iconAllowsOverlap = MGLStyleValue(rawValue: 1)
+        symbolLayer.iconImageName = NSExpression(forConstantValue: "unselected_marker")
+        symbolLayer.iconAllowsOverlap = NSExpression(forConstantValue: 1)
         
         style.addLayer(symbolLayer)
         
@@ -132,11 +134,12 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
         
         userLocationSource = MGLShapeSource(identifier: "user-location", features: [userLocationFeature], options: nil)
         let userLocationStyle = MGLCircleStyleLayer(identifier: "user-location-style", source: userLocationSource!)
-        userLocationStyle.circleColor = MGLStyleValue(rawValue: (viewControllerTheme?.themeColor.primaryDarkColor)!) // Set the color for the user location dot, if applicable.
-        userLocationStyle.circleRadius = MGLStyleValue(rawValue: 7)
-        userLocationStyle.circleStrokeColor = MGLStyleValue(rawValue: (viewControllerTheme?.themeColor.primaryDarkColor)!)
-        userLocationStyle.circleStrokeWidth = MGLStyleValue(rawValue: 4)
-        userLocationStyle.circleStrokeOpacity = MGLStyleValue(rawValue: 0.5)
+        // Set the color for the user location dot, if applicable.
+        userLocationStyle.circleColor = NSExpression(forConstantValue: viewControllerTheme?.themeColor.primaryDarkColor)
+        userLocationStyle.circleRadius = NSExpression(forConstantValue: 7)
+        userLocationStyle.circleStrokeColor = NSExpression(forConstantValue: viewControllerTheme?.themeColor.primaryDarkColor)
+        userLocationStyle.circleStrokeWidth = NSExpression(forConstantValue: 4)
+        userLocationStyle.circleStrokeOpacity = NSExpression(forConstantValue: 0.5)
         
         style.addSource(userLocationSource!)
         style.addLayer(userLocationStyle)
@@ -179,13 +182,11 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
         if let name = feature.attribute(forKey: "name") as? String {
             
             // Change the icon to the selected icon based on the feature name. If multiple items have the same name, choose an attribute that is unique.
-            layer.iconImageName = MGLStyleValue(interpolationMode: .categorical,
-                                                sourceStops: [name: MGLStyleValue<NSString>(rawValue: "purple_selected_burger")],
-                                                attributeName: "name",
-                                                options: [.defaultValue: MGLStyleValue<NSString>(rawValue: "purple_unselected_burger")])
+            layer.iconImageName = NSExpression(format: "MGL_MATCH(name, %@, 'selected_marker', 'unselected_marker')", name)
+            
         } else {
             // Deselect all items if no feature was selected.
-            layer.iconImageName = MGLStyleValue(rawValue: "purple_unselected_burger")
+            layer.iconImageName = NSExpression(forConstantValue: "unselected_marker")
         }
     }
     
@@ -240,9 +241,11 @@ class ThemeViewController: UIViewController, MGLMapViewDelegate, CLLocationManag
                 self.mapView.style?.addSource(source)
                 
                 let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
-                lineStyle.lineColor = MGLStyleValue(rawValue: (self.viewControllerTheme?.themeColor.navigationLineColor)!) // Set the line color to the theme's color.
-                lineStyle.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
-                lineStyle.lineWidth = MGLStyleValue(rawValue: 3)
+                
+                // Set the line color to the theme's color.
+                lineStyle.lineColor = NSExpression(forConstantValue: self.viewControllerTheme?.themeColor.navigationLineColor)
+                lineStyle.lineJoin = NSExpression(forConstantValue: NSValue(mglLineCap: .round))
+                lineStyle.lineWidth = NSExpression(forConstantValue: 3)
                 
                 if let userDot = mapView.style?.layer(withIdentifier: "user-location-style") {
                     self.mapView.style?.insertLayer(lineStyle, below: userDot)

--- a/mapbox-store-locator/Themes.swift
+++ b/mapbox-store-locator/Themes.swift
@@ -29,12 +29,12 @@ class MBXTheme : NSObject {
                                   fileURL: Bundle.main.url(forResource: "stores", withExtension: "geojson")!)
     static let grayTheme = Theme(defaultMarker: UIImage(named: "white_unselected_bike")!,
                                  selectedMarker: UIImage(named: "gray_selected_bike")!,
-                                 styleURL: MGLStyle.lightStyleURL(),
+                                 styleURL: MGLStyle.lightStyleURL,
                                  themeColor: ThemeColor.grayTheme,
                                  fileURL: Bundle.main.url(forResource: "stores", withExtension: "geojson")!)
     static let neutralTheme = Theme(defaultMarker: UIImage(named: "blue_unselected_house")!,
                                     selectedMarker: UIImage(named: "blue_selected_house")!,
-                                    styleURL: MGLStyle.streetsStyleURL(),
+                                    styleURL: MGLStyle.streetsStyleURL,
                                     themeColor: ThemeColor.neutralTheme,
                                     fileURL: Bundle.main.url(forResource: "stores", withExtension: "geojson")!)
     static let themes: [Theme] = [


### PR DESCRIPTION
Closes #6 

Upgrades code to use `NSExpression` for data-driven styling components as introduced in v4.0.0 of the [Maps SDK for iOS](https://github.com/mapbox/mapbox-gl-native/releases). Also upgrades MapboxDirections.swift.